### PR TITLE
Update preupgrade-assistant.conf

### DIFF
--- a/preup-conf/preupgrade-assistant.conf
+++ b/preup-conf/preupgrade-assistant.conf
@@ -9,5 +9,11 @@ user_config_file=enabled
 # Otherwise directories/files can be skipped.
 # if you want to add directories items which start with "#" or looks likes
 # config section, supported format is ./#name or ./[something]
+# Please note , that this a default systemwide configuration, for user specific 
+# configuration please use ~/.preupgrade_whitelist and ~/.preupgrade_blacklist. 
+# Entry to whitelist must be a valid basename of subdirectory of user's home directory.
+# Entry to blacklist must be a valid basename of subdirectory of user's home directory or 
+# whitelist entry (if that exists). Comments and trailing slashes are not supported in
+# whitelist/blacklist.
 .config/
 .mozilla/


### PR DESCRIPTION
This is a proposed entry to preupgrade-assistant.conf, that explains the usage of user specific whitelist/blacklist
